### PR TITLE
#113 fix 友達のデータをダミーからログイン時に取得した友達一覧の内容に変更

### DIFF
--- a/lend_frontend/src/App.tsx
+++ b/lend_frontend/src/App.tsx
@@ -20,6 +20,7 @@ import AppContext from "./contexts/AppContexts";
 
 const initialState = {
   user: {},
+  friends: [],
 };
 
 function App() {

--- a/lend_frontend/src/actions/index.ts
+++ b/lend_frontend/src/actions/index.ts
@@ -1,1 +1,3 @@
 export const CREATE_USER = "user/create_user";
+
+export const ADD_FRIEND_TO_LIST = "friends/add_friend_list";

--- a/lend_frontend/src/components/BookCard/BookCard.tsx
+++ b/lend_frontend/src/components/BookCard/BookCard.tsx
@@ -15,28 +15,27 @@ import Book from "../../model/book";
 type CardType = "read_lend" | "buy" | "read_buy_return" | "lending_label";
 
 interface BookCardProps {
-  book: Book,
-  type?: CardType,
+  book: Book;
+  type?: CardType;
 }
 
 const BookCard = ({ book, type = "read_lend" }: BookCardProps): JSX.Element => {
   const history = useHistory();
 
-  const handleRead = () => {
-
   const handleLend = () => {
-    history.push(`/mybook/${props.book.id}/lend`);
+    history.push(`/mybook/${book.id}/lend`);
   };
+
+  const handleRead = () => {
     history.push(`/mybook/${book.id}/read`);
-  }
+  };
 
   // 購入の場合のみ、カードをクリックしてアクションを起こせる
   const handleBuy = () => {
-    if(type === "buy"){
-      console.log("購入")
+    if (type === "buy") {
+      console.log("購入");
     }
-  }
-
+  };
 
   return (
     <div className="BookCard" onClick={handleBuy}>
@@ -56,29 +55,27 @@ const BookCard = ({ book, type = "read_lend" }: BookCardProps): JSX.Element => {
         </div>
       </div>
       {/* 購入以外は、フッターにボタンを表示する */}
-      {
-        type !== "buy" && (
-          <div className="BookCard__under">
-            {
-              type === "read_lend" ? (
-                <>
-                  <Button content="読む" onClick={handleRead} />
-                  <Button content="貸す" onClick={() => console.log("貸す")} />
-                </>
-              ) : type === "read_buy_return" ? (
-                <>
-                  <Button content="読む" onClick={handleRead} />
-                  <Button content="購入" onClick={() => console.log("購入")} />
-                  <Button content="貸す" onClick={() => console.log("貸す")} />
-                </>
-              ) : type === "lending_label" && (
-                // TODO: デザイン未確認
-                <div>貸し出し中です</div>
-              )
-            }
-          </div>
-        )
-      }
+      {type !== "buy" && (
+        <div className="BookCard__under">
+          {type === "read_lend" ? (
+            <>
+              <Button content="読む" onClick={handleRead} />
+              <Button content="貸す" onClick={handleLend} />
+            </>
+          ) : type === "read_buy_return" ? (
+            <>
+              <Button content="読む" onClick={handleRead} />
+              <Button content="購入" onClick={() => console.log("購入")} />
+              <Button content="貸す" onClick={handleLend} />
+            </>
+          ) : (
+            type === "lending_label" && (
+              // TODO: デザイン未確認
+              <div>貸し出し中です</div>
+            )
+          )}
+        </div>
+      )}
     </div>
   );
 };

--- a/lend_frontend/src/components/Login/Login.tsx
+++ b/lend_frontend/src/components/Login/Login.tsx
@@ -2,14 +2,14 @@ import React, { useState, useContext } from "react";
 import { useHistory } from "react-router-dom";
 import axios from "axios";
 import AppContext from "../../contexts/AppContexts";
-import { CREATE_USER } from "../../actions/";
+import { CREATE_USER, ADD_FRIEND_TO_LIST } from "../../actions/";
 
 const ENTRY_POINT = process.env.REACT_APP_API_ENTRYPOINT;
 
 const Login = () => {
   const history = useHistory();
 
-  const { dispatch } = useContext(AppContext);
+  const { state, dispatch } = useContext(AppContext);
   const [registerFlag, setRegisterFlag] = useState(false);
 
   const [userName, setUserName] = useState("kirin");
@@ -32,6 +32,16 @@ const Login = () => {
           dispatch({
             type: CREATE_USER,
             user: res.data,
+          });
+          res.data.friend_list.forEach((friend: Array<any>) => {
+            dispatch({
+              type: ADD_FRIEND_TO_LIST,
+              friend: {
+                id: friend[0],
+                icon_image: friend[1],
+                name: friend[2],
+              },
+            });
           });
           history.push(`/mybook/`);
         });
@@ -68,7 +78,6 @@ const Login = () => {
       <button className="login-form-submit" onClick={handleSubmit}>
         {registerFlag ? "新規登録" : "ログイン"}
       </button>
-
     </div>
   );
 };

--- a/lend_frontend/src/components/SelectFriendScreen/SelectFriendScreen.tsx
+++ b/lend_frontend/src/components/SelectFriendScreen/SelectFriendScreen.tsx
@@ -9,7 +9,6 @@ import { RouteComponentProps } from "react-router-dom";
 import FriendColumn from "./FriendColumn/FriendColumn";
 import BaseModal from "@material-ui/core/Modal";
 import ModalContentConfirm from "../Modal/ModalContentConfirm/ModalContentConfirm";
-import friends from "./Friends.json";
 import Screen from "../Screen/Screen";
 import AppContext from "../../contexts/AppContexts";
 import calculateDeadline from "../../CalculateDeadline";
@@ -17,6 +16,11 @@ import "./_SelectFriendScreen.scss";
 import axios from "axios";
 interface SelectFriendScreenProps extends RouteComponentProps<{ id: string }> {
   lendBookName: string;
+}
+interface FriendsState {
+  id: number;
+  icon_image: string;
+  name: string;
 }
 
 const ENTRY_POINT = process.env.REACT_APP_API_ENTRYPOINT;
@@ -28,6 +32,7 @@ const SelectFriendScreen = (props: SelectFriendScreenProps) => {
   const [isModalOpen, setModalOpen] = useState<boolean>(false);
 
   const [lendUsername, setLendUsername] = useState<string>("");
+  const [lendUserId, setlendUserId] = useState<number>(0);
 
   const messagesDomRef = useRef<HTMLDivElement>(null);
   useEffect(() => {
@@ -42,7 +47,8 @@ const SelectFriendScreen = (props: SelectFriendScreenProps) => {
     e.target.value === "" ? setIsSearch(false) : setIsSearch(true);
   }, []);
 
-  const handleModalOpen = (friendName: string) => {
+  const handleModalOpen = (friendName: string, friendId: number) => {
+    setlendUserId(friendId);
     setLendUsername(friendName);
     setModalOpen(true);
   };
@@ -55,12 +61,12 @@ const SelectFriendScreen = (props: SelectFriendScreenProps) => {
     await axios
       .post(ENTRY_POINT + "/lend", {
         id: state.user.id,
-        borrower_id: 1,
+        borrower_id: lendUserId.toString(),
         book_id: props.match.params.id,
-        deadline: calculateDeadline(2),
+        deadline: calculateDeadline(1),
       })
       .then((res) => {
-        console.log("res: ");
+        console.log("SelectFriendScreen res: ");
         console.log(res);
       });
     handleModalClose();
@@ -87,14 +93,16 @@ const SelectFriendScreen = (props: SelectFriendScreenProps) => {
           </div>
         </div>
         <div className="select_friend_screen__friend_list">
-          {friends.friends.map((friend) => {
+          {state.friends.map((friend: FriendsState, index: number) => {
             if (isSearch) {
               return searchText === friend.name ? (
-                <span onClick={() => handleModalOpen(friend.name)}>
+                <span
+                  onClick={() => handleModalOpen(friend.name, friend.id)}
+                  key={index}
+                >
                   <FriendColumn
-                    key={friend.id}
                     name={friend.name}
-                    iconImageURL={friend.iconImageURL}
+                    iconImageURL={friend.icon_image}
                   />
                 </span>
               ) : (
@@ -102,11 +110,13 @@ const SelectFriendScreen = (props: SelectFriendScreenProps) => {
               );
             } else {
               return (
-                <span onClick={() => handleModalOpen(friend.name)}>
+                <span
+                  onClick={() => handleModalOpen(friend.name, friend.id)}
+                  key={index}
+                >
                   <FriendColumn
-                    key={friend.id}
                     name={friend.name}
-                    iconImageURL={friend.iconImageURL}
+                    iconImageURL={friend.icon_image}
                   />
                 </span>
               );
@@ -123,7 +133,7 @@ const SelectFriendScreen = (props: SelectFriendScreenProps) => {
       >
         <div className="modal_background">
           <ModalContentConfirm
-            description={`${props.lendBookName} を ${lendUsername} さんに貸し出しても良いですか?`}
+            description={`${lendUsername} さんに貸し出しても良いですか?`}
             onConfirm={onConfirm}
             onDeny={onDeny}
           />

--- a/lend_frontend/src/reducers/friends.ts
+++ b/lend_frontend/src/reducers/friends.ts
@@ -1,0 +1,21 @@
+import { ADD_FRIEND_TO_LIST } from "../actions";
+
+interface friendAction {
+  type: string;
+  friend: {
+    id: number;
+    icon_image: string;
+    name: string;
+  };
+}
+
+const friends = (state = [{}], action: friendAction) => {
+  switch (action.type) {
+    case ADD_FRIEND_TO_LIST:
+      return [...state, action.friend];
+    default:
+      return state;
+  }
+};
+
+export default friends;

--- a/lend_frontend/src/reducers/index.ts
+++ b/lend_frontend/src/reducers/index.ts
@@ -1,4 +1,5 @@
 import { combineReducers } from "redux";
 import user from "./user";
+import friends from "./friends";
 
-export default combineReducers({ user });
+export default combineReducers({ user, friends });


### PR DESCRIPTION
## 実装内容
- ログイン時に取得した友達一覧をContextAPIを用いてグローバルなstoreに保持
- 貸し出し友達一覧をダミーデータからログイン時に取得したデータに変更
![image](https://user-images.githubusercontent.com/19424097/93407859-1f483a00-f8ce-11ea-9e11-71d1765951b7.png)
